### PR TITLE
Rename 'Scan' 'Circulation' in displays (menu bar, settings). UIS-17.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "stripes": {
     "type": "app",
-    "displayName": "Scan",
+    "displayName": "Circulation",
     "route": "/scan",
     "hasSettings": true,
     "okapiInterfaces": {


### PR DESCRIPTION
  project, path, routes not renamed as Scan is being split up in
  multiple apps as per UIS-84.